### PR TITLE
fix: simplify brew PATH append after system's

### DIFF
--- a/system_files/etc/profile.d/brew.sh
+++ b/system_files/etc/profile.d/brew.sh
@@ -4,5 +4,6 @@
 # See: https://github.com/ublue-os/brew/blob/54b30cc07d3211fca65ca5cc724e9812c8c79b77/system_files/usr/lib/systemd/system/brew-upgrade.service#L17-L22
 if [[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] ; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv | grep -Ev '\bPATH=')"
+  HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
   export PATH="${PATH}:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin"
 fi


### PR DESCRIPTION
This restores compatibility with upstream changes in shellenv.sh that don't affect the PATH

Credits: https://github.com/orgs/Homebrew/discussions/2560#discussioncomment-1716820