### PR TITLE
feat: apply --depth=1 to git fetch commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   IMAGE_KEYWORDS: "homebrew"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/136393846?s=200&v=4"
   IMAGE_NAME: "${{ github.event.repository.name }}"
-  IMAGE_REGISTRY: "ghcr.io/lumaeris"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   DEFAULT_TAG: "latest"
 
 jobs:

--- a/cosign.pub
+++ b/cosign.pub
@@ -1,4 +1,4 @@
 -----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDlyvWu3deeCU+pU0bg3oQ3LSfeyW
-f9nb52ebgv3tMzNbxFwWVbdiU4gu92cy/dkWg/BlnQo9LH+f9aMUjxrSwA==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHLRpBfPRYiMl9wb7s6fx47PzzNWu
+3zyJgXhWEvxoOgwv9CpwjbvUwR9qHxNMWkJhuGE6cjDA2hpy1I6NbA+24Q==
 -----END PUBLIC KEY-----


### PR DESCRIPTION
This PR adds a diff file that simply appends `--depth=1` to `git apply` in order to do shallow clone in install script. This change alone can reduce homebrew package from 128.6 MB down to 60.8 MB, a bit more than a half!

Please note that after doing some research Homebrew doesn't recommend doing so since it may break updating Homebrew itself and its taps as of 4 years ago, not sure how it changed from then. It goes without saying that it needs more testing. Feel free to use `ghcr.io/lumaeris/brew:latest` though!

Relevant issue: https://github.com/Homebrew/brew/issues/11693

<img width="344" height="217" alt="Screenshot From 2026-01-05 11-31-00" src="https://github.com/user-attachments/assets/b152e434-4907-4383-9918-6b016b7d1b9d" />
