### PR TITLE
fix: avoid initializing homebrew if already initialized

### DIFF
--- a/system_files/etc/profile.d/brew.sh
+++ b/system_files/etc/profile.d/brew.sh
@@ -2,7 +2,7 @@
 
 # Prioritize system binaries to prevent brew overriding things like dbus
 # See: https://github.com/ublue-os/brew/blob/54b30cc07d3211fca65ca5cc724e9812c8c79b77/system_files/usr/lib/systemd/system/brew-upgrade.service#L17-L22
-if [[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] ; then
+if [[ $- == *i* && -z "${HOMEBREW_PREFIX:-}" && -d /home/linuxbrew/.linuxbrew ]]; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv | grep -Ev '\bPATH=')"
   HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
   export PATH="${PATH}:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin"


### PR DESCRIPTION
This change addresses two main issues:

* brew is no longer duplicated in PATH
* brew is not initialized multiple times

As described in [0], brew was being initialized multiple times on events such as:

* `source ~/.bashrc`
* `omz reload`
* launching tmux

Also, the homebrew directory check is moved to the end to avoid a system I/O call unless absolutely necessary. After applying this change, `hyperfine 'bash -i -c exit'` shows an improvement of ~30 ms on my system.

[0] https://github.com/ublue-os/brew/issues/18