### PR TITLE
fix: (fish) deprioritise homebrew binaries below system binaries.

### DIFF
--- a/system_files/usr/share/fish/vendor_conf.d/ublue-brew.fish
+++ b/system_files/usr/share/fish/vendor_conf.d/ublue-brew.fish
@@ -1,13 +1,17 @@
 #!/usr/bin/fish
 #shellcheck disable=all
 if status --is-interactive
-    if [ -d /home/linuxbrew/.linuxbrew ]
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv fish)"
+    if test -d /home/linuxbrew/.linuxbrew
+        /home/linuxbrew/.linuxbrew/bin/brew shellenv fish | source
+
+        # Prioritize system binaries to prevent brew overriding things like dbus
+        fish_add_path --move --append --path (brew --prefix)/bin (brew --prefix)/sbin
+
         if test -d (brew --prefix)/share/fish/completions
-            set -p fish_complete_path (brew --prefix)/share/fish/completions
+            set -ga fish_complete_path (brew --prefix)/share/fish/completions
         end
         if test -d (brew --prefix)/share/fish/vendor_completions.d
-            set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+            set -ga fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
         end
     end
 end


### PR DESCRIPTION
This makes the fish shell behaviour consistent with bash. As well as some clean up of the script, but let me know if there are too many changes at once.

https://github.com/ublue-os/bluefin/issues/4266

* Update fish ublue-brew.fish to move homebrew paths to the end of $PATH.
* Move auto complete to the end for consistency.
* Add explicit -g for global scope rather than relying on implicit behaviour.
* Update sourcing to be more idiomatic.
* update directory test to be consistent and idomatic.