### PR TITLE
fix: do not add to $PATH twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ Automatically upgrades installed packages:
 - **Tmpfiles**: `/usr/lib/tmpfiles.d/homebrew.conf`
 - **Systemd Presets**: `/usr/lib/systemd/system-preset/01-homebrew.preset`
 
-## How do I override system binaries with homebrew ones?
+## Known limitations
+
+- Launching desktops from the TTY causes linuxbrew to be present in non-interactive shells (krunner, rofi). See [this](https://github.com/ublue-os/brew/issues/24#issuecomment-4574594563).
+
+### How do I override system binaries with homebrew ones?
 
 As discussed [here](https://github.com/ublue-os/brew/pull/1), overriding system
 provided binaries can lead to some unexpected issues, but it might still be

--- a/system_files/etc/profile.d/brew.sh
+++ b/system_files/etc/profile.d/brew.sh
@@ -2,7 +2,7 @@
 
 # Prioritize system binaries to prevent brew overriding things like dbus
 # See: https://github.com/ublue-os/brew/blob/54b30cc07d3211fca65ca5cc724e9812c8c79b77/system_files/usr/lib/systemd/system/brew-upgrade.service#L17-L22
-if [[ $- == *i* && -z "${HOMEBREW_PREFIX:-}" && -d /home/linuxbrew/.linuxbrew ]]; then
+if [[ $- == *i* && -z "${HOMEBREW_PREFIX:-}" && -d /home/linuxbrew/.linuxbrew && ! "$PATH" =~ "/home/linuxbrew.linuxbrew" ]]; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv | grep -Ev '\bPATH=')"
   HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
   export PATH="${PATH}:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin"


### PR DESCRIPTION
TTY is an interactive shell and when you launch your desktop this way
(not through a Display Manager) then the linuxbrew directory in the
$PATH will be inherited and in turn causes non-interactive shells to
have linuxbrew, this is noticeable in things like krunner and rofi.

It's still at the end of the $PATH so system binaries will have
precedence and it should not break anything.

Having brew on the TTY in $PATH is useful so I think this is a fine
workaround. I don't see a way for us to not make it so that this
specifically is not inherited to the desktop.

This fixes the cosmetic issue of it being present twice in $PATH.

This was brought up in [1].

[1]: https://github.com/ublue-os/brew/issues/24#issuecomment-4574594563